### PR TITLE
Fixed XNA 1.0 conversion

### DIFF
--- a/Alba.XnaConvert.Loader.Xna10/ContentService.cs
+++ b/Alba.XnaConvert.Loader.Xna10/ContentService.cs
@@ -44,7 +44,7 @@ namespace Alba.XnaConvert.Loader.Xna10
                 _form = new Form();
                 GraphicsDevice = new GraphicsDevice(
                     GraphicsAdapter.DefaultAdapter, DeviceType.Hardware, _form.Handle,
-                    new CreateOptions(),
+                    CreateOptions.HardwareVertexProcessing,
                     new PresentationParameters { IsFullScreen = false });
             }
         }


### PR DESCRIPTION
The empty CreateOptions constructor argument in the XNA 1.0 GraphicsDevice constructor was causing an invalid method call error as shown in issues such as https://github.com/Athari/XnaConvert/issues/12. This code changes that parameter to a proper hardware-processing CreateOption, fixing the issue and allowing for successful conversion.